### PR TITLE
Replaces sync API with async API

### DIFF
--- a/src/ThorNet.Sample/Program.cs
+++ b/src/ThorNet.Sample/Program.cs
@@ -86,9 +86,9 @@ namespace ThorNet.Sample
             if (verbose) { Console.WriteLine("> done saying hello"); }
         }
 
-        public static int Main(string[] args)
+        public static Task<int> Main(string[] args)
         {
-            return Start<Program>(args);
+            return StartAsync<Program>(args);
         }
     }
 }

--- a/src/ThorNet/Thor.cs
+++ b/src/ThorNet/Thor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace ThorNet
 {
@@ -116,8 +117,8 @@ namespace ThorNet
         /// </summary>
         /// <param name="commandName">The name of the command to invoke.</param>
         /// <param name="args">The arguments to provide to the command.</param>
-        /// <returns>The exit code to return to the command prompt.</returns>
-        internal int Invoke(string commandName, string[] args)
+        /// <returns>A task that represents the asynchronous operation. The task result contains the exit code to return to the command prompt.</returns>
+        internal async Task<int> InvokeAsync(string commandName, string[] args)
         {
             // Show warnings for any public methods that don't have examples defined.
             foreach (string invalid in Commands.Where(p => string.IsNullOrEmpty(p.Value.Example))
@@ -129,7 +130,7 @@ namespace ThorNet
             ThorCommand command;
             if (Commands.TryGetValue(commandName, out command))
             {
-                try { return command.Invoke(args); }
+                try { return await command.InvokeAsync(args); }
                 catch (TargetInvocationException ex)
                 {
                     return HandleException(ex.InnerException);
@@ -145,7 +146,7 @@ namespace ThorNet
                 if (TryGetSubcommand(commandName, out subcommand))
                 {
                     commandName = PrepareInvocationArguments(ref args);
-                    return subcommand.Invoke(commandName, args);
+                    return await subcommand.InvokeAsync(commandName, args);
                 }
 
                 else
@@ -260,7 +261,7 @@ namespace ThorNet
         }
 
         /// <summary>
-        /// Prepares the input arguments to invoke <see cref="Thor.Invoke(string, string[])"/>
+        /// Prepares the input arguments to invoke <see cref="Thor.InvokeAsync(string, string[])"/>
         /// </summary>
         /// <param name="args">The array of arguments provided.  This is modified to remove the first argument if present.</param>
         /// <returns>The name of the command to invoke.  If no arguments are provided, this defaults to <see cref="Help(string, string[])"/>.</returns>
@@ -490,14 +491,14 @@ namespace ThorNet
         /// Starts the thor program.
         /// </summary>
         /// <param name="args">The arguments given from the command line.</param>
-        /// <returns>The exit code to return to the command prompt.</returns>
-        public static int Start<T>(string[] args)
+        /// <returns>A task that represents the asynchronous operation. The task result contains the exit code to return to the command prompt.</returns>
+        public static async Task<int> StartAsync<T>(string[] args)
             where T : Thor, new()
         {
             string commandName = PrepareInvocationArguments(ref args);
 
             T thor = new T();
-            return thor.Invoke(commandName, args);
+            return await thor.InvokeAsync(commandName, args);
         }
 
         /// <summary>

--- a/src/ThorNet/ThorCommand.cs
+++ b/src/ThorNet/ThorCommand.cs
@@ -77,7 +77,7 @@ namespace ThorNet
              .ToDictionary(x => x.Key, x => x.Option);
         }
 
-        public int Invoke(string[] args)
+        public async Task<int> InvokeAsync(string[] args)
         {
             try
             {
@@ -96,13 +96,11 @@ namespace ThorNet
                 object result = _command.Invoke(_host, arguments);
 
                 // If the result is a task, then make sure to wait for it to complete.  
-                if (typeof(Task).GetTypeInfo().IsAssignableFrom(_command.ReturnType))
+                if (result is Task task)
                 {
-                    Task task = (Task)result;
-                    task.Wait();
+                    await task;
 
-                    var intTask = task as Task<int>;
-                    if (intTask != null)
+                    if (task is Task<int> intTask)
                     {
                         return intTask.Result;
                     }

--- a/tests/ThorNet.UnitTests/AliasTests.cs
+++ b/tests/ThorNet.UnitTests/AliasTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace ThorNet.UnitTests
@@ -8,31 +9,31 @@ namespace ThorNet.UnitTests
     public class AliasTests
     {
         [Fact]
-        public void Invoke_ShouldCallCommand_GivenAlias()
+        public async Task Invoke_ShouldCallCommand_GivenAlias()
         {
             var message = Guid.NewGuid().ToString();
             
             var thor = new T();
-            thor.Invoke("handle", new[] { message });
+            await thor.InvokeAsync("handle", new[] { message });
 
             Assert.Equal(message, thor.Message);
         }
 
         [Fact]
-        public void Invoke_ShouldCallCommand_GivenMethodName()
+        public async Task Invoke_ShouldCallCommand_GivenMethodName()
         {
             var message = Guid.NewGuid().ToString();
 
             var thor = new T();
-            thor.Invoke(nameof(T.Handle), new[] { message });
+            await thor.InvokeAsync(nameof(T.Handle), new[] { message });
 
             Assert.Equal(message, thor.Message);
         }
 
         [Fact]
-        public void Help_ShouldPrintAlias_GivenAlias()
+        public async Task Help_ShouldPrintAlias_GivenAlias()
         {
-            var lines = GetHelp();
+            var lines = await GetHelpAsync();
 
             var actual = Assert.Single(
                 lines.Where(
@@ -44,9 +45,9 @@ namespace ThorNet.UnitTests
         }
 
         [Fact]
-        public void Help_ShouldPrintMethodName_GivenNoAlias()
+        public async Task Help_ShouldPrintMethodName_GivenNoAlias()
         {
-            var lines = GetHelp();
+            var lines = await GetHelpAsync();
 
             var actual = Assert.Single(
                 lines.Where(
@@ -57,13 +58,13 @@ namespace ThorNet.UnitTests
             Assert.Equal(expected, actual);
         }
 
-        static IEnumerable<string> GetHelp()
+        static async Task<IEnumerable<string>> GetHelpAsync()
         {
             var terminal = new MockTerminal(100);
 
             var commandName = nameof(Thor.Help);
             var args = new string[0];
-            new T(terminal).Invoke(commandName, args);
+            await new T(terminal).InvokeAsync(commandName, args);
 
             return terminal.GetLines();
         }

--- a/tests/ThorNet.UnitTests/ExceptionHandlingTests.cs
+++ b/tests/ThorNet.UnitTests/ExceptionHandlingTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace ThorNet.UnitTests
@@ -7,11 +8,11 @@ namespace ThorNet.UnitTests
     public class ExceptionHandlingTests
     {
         [Fact]
-        public void Invoke_ShouldUnwrapTargetInvocationException_GivenThrownException()
+        public async Task Invoke_ShouldUnwrapTargetInvocationException_GivenThrownException()
         {
             var message = Guid.NewGuid().ToString();
             var terminal = new MockTerminal(100);
-            new E(terminal).Invoke(nameof(E.Throw), new[] { message });
+            await new T(terminal).InvokeAsync(nameof(T.Throw), new[] { message });
 
             var actual = Assert.Single(
                 terminal.GetLines().Where(line => line.StartsWith("[ERROR]"))
@@ -21,9 +22,9 @@ namespace ThorNet.UnitTests
             Assert.Equal(expected, actual);
         }
 
-        public class E : Thor
+        public class T : Thor
         {
-            public E(ITerminal terminal)
+            public T(ITerminal terminal)
                 : base(terminal)
             {
             }

--- a/tests/ThorNet.UnitTests/ExitTests.cs
+++ b/tests/ThorNet.UnitTests/ExitTests.cs
@@ -22,11 +22,11 @@ namespace ThorNet.UnitTests
         [InlineData("SubTarget,Invalid", 1)]
         [InlineData("SubTarget,Throws", 1)]
         [Theory]
-        public void Test(string argsList, int exitCode)
+        public async Task Test(string argsList, int exitCode)
         {
             string[] args = Utility.ToArray(argsList);
 
-            int actual = Thor.Start<Target>(args);
+            int actual = await Thor.StartAsync<Target>(args);
             Assert.Equal(exitCode, actual);
         }
 

--- a/tests/ThorNet.UnitTests/OptionTests.cs
+++ b/tests/ThorNet.UnitTests/OptionTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace ThorNet.UnitTests
@@ -10,10 +11,10 @@ namespace ThorNet.UnitTests
         [InlineData("Test,--class=A,--classDefault=B,--method=C,--methodDefault=D", "A,B,C,D")]
         [InlineData("Test,-cA,-dB,-mC,-nD", "A,B,C,D")]
         [Theory]
-        public void Option_Tests(string args, string values)
+        public async Task Option_Tests(string args, string values)
         {
             Target.OptionValues = new Options();
-            Thor.Start<Target>(Utility.ToArray(args));
+            await Thor.StartAsync<Target>(Utility.ToArray(args));
 
             var valuesList = Utility.ToArray(values);
 
@@ -24,9 +25,9 @@ namespace ThorNet.UnitTests
         }
 
         [Fact]
-        public void Help_ShouldIncludeHyphen_GivenAliasWithoutHyphen()
+        public async Task Help_ShouldIncludeHyphen_GivenAliasWithoutHyphen()
         {
-            var lines = GetHelp();
+            var lines = await GetHelpAsync();
 
             var actual = Assert.Single(
                 lines.Where(line => line.Trim().StartsWith("-c"))
@@ -37,9 +38,9 @@ namespace ThorNet.UnitTests
         }
 
         [Fact]
-        public void Help_ShouldIncludeHyphen_GivenAliasWithHyphen()
+        public async Task Help_ShouldIncludeHyphen_GivenAliasWithHyphen()
         {
-            var lines = GetHelp();
+            var lines = await GetHelpAsync();
 
             var actual = Assert.Single(
                 lines.Where(line => line.Trim().StartsWith("-n"))
@@ -49,7 +50,7 @@ namespace ThorNet.UnitTests
             Assert.Equal(expected, actual);
         }
 
-        static IEnumerable<string> GetHelp()
+        static async Task<IEnumerable<string>> GetHelpAsync()
         {
             var terminal = new MockTerminal(100);
 
@@ -58,7 +59,7 @@ namespace ThorNet.UnitTests
             {
                 nameof(Target.Test)
             };
-            new Target(terminal).Invoke(commandName, args);
+            await new Target(terminal).InvokeAsync(commandName, args);
 
             return terminal.GetLines();
         }

--- a/tests/ThorNet.UnitTests/SubcommandTests.cs
+++ b/tests/ThorNet.UnitTests/SubcommandTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace ThorNet.UnitTests
@@ -32,10 +33,10 @@ namespace ThorNet.UnitTests
         }
 
         [Fact]
-        public void Subcommand_IsTriggered()
+        public async Task Subcommand_IsTriggered()
         {
             Assert.Equal(0, Trigger.Counter);
-            Thor.Start<TriggerTarget>(new[] { nameof(Trigger), nameof(Trigger.Increment) });
+            await Thor.StartAsync<TriggerTarget>(new[] { nameof(Trigger), nameof(Trigger.Increment) });
             Assert.Equal(1, Trigger.Counter);
         }
 


### PR DESCRIPTION
This is to avoid the anti-pattern of sync-over-async. The original implementation was required, due to the lack of support for `Task` return values in Console Applications.